### PR TITLE
Tweak to Pot usage

### DIFF
--- a/Sepulcher of the First Ones/Anduin Wrynn/sv-apl.simc
+++ b/Sepulcher of the First Ones/Anduin Wrynn/sv-apl.simc
@@ -53,7 +53,7 @@ actions.cds+=/lights_judgment
 actions.cds+=/bag_of_tricks,if=cooldown.kill_command.full_recharge_time>gcd
 actions.cds+=/berserking,if=buff.coordinated_assault.up|time_to_die<13
 actions.cds+=/muzzle
-actions.cds+=/potion,if=target.time_to_die<25|buff.coordinated_assault.up
+actions.cds+=/potion,if=buff.bloodlust.up|buff.coordinated_assault.up&raid_event.vulnerable.remains|time_to_die<25
 actions.cds+=/fleshcraft,cancel_if=channeling&!soulbind.pustule_eruption,if=(focus<70|cooldown.coordinated_assault.remains<gcd)&(soulbind.pustule_eruption|soulbind.volatile_solvent)
 actions.cds+=/tar_trap,if=focus+cast_regen<focus.max&runeforge.soulforge_embers.equipped&tar_trap.remains<gcd&cooldown.flare.remains<gcd&(active_enemies>1|active_enemies=1&time_to_die>5*gcd)
 actions.cds+=/flare,if=focus+cast_regen<focus.max&tar_trap.up&runeforge.soulforge_embers.equipped&time_to_die>4*gcd


### PR DESCRIPTION
Change pot to be used with bloodlust or during Remnant phase.
Sim comparing difference: https://www.raidbots.com/simbot/report/sFQBotntfwvrKRr2jkHZHX