### PR TITLE
add smolderon raid encountter

### DIFF
--- a/Amirdrassil/Smolderon/encounter.simc
+++ b/Amirdrassil/Smolderon/encounter.simc
@@ -6,7 +6,7 @@ vary_combat_length=0.02
 enemy=smolderon
 
 override.bloodlust=1
-bloodlust_time=360
+bloodlust_time=262
 
 
 raid_events+=/vulnerable,first=69,cooldown=1000,duration=20

--- a/Amirdrassil/Smolderon/encounter.simc
+++ b/Amirdrassil/Smolderon/encounter.simc
@@ -1,0 +1,15 @@
+# about 6:50 min in length
+max_time=410
+vary_combat_length=0.02
+
+
+enemy=smolderon
+
+override.bloodlust=1
+bloodlust_time=360
+
+
+raid_events+=/vulnerable,first=69,cooldown=1000,duration=20
+raid_events+=/vulnerable,first=169,cooldown=1000,duration=20
+raid_events+=/vulnerable,first=269,cooldown=1000,duration=20
+raid_events+=/vulnerable,first=365,cooldown=1000,duration=20


### PR DESCRIPTION
I wanted to test CTS interactions on marksman, so I thought it made sense to create the smolderon encounter

I chose vulnerability vs having a custom buff (which could be stacked 20,40,60 etc) because then I can see if the boss is vulnerable when testing apl differences (hold for amp phases)